### PR TITLE
Add [kde-unstable] support

### DIFF
--- a/src/Web/ArchLinux/Types.hs
+++ b/src/Web/ArchLinux/Types.hs
@@ -72,6 +72,7 @@ data Repo
   | MultilibTesting
   | Community
   | CommunityTesting
+  | KDEUnstable
   deriving stock (Show, Eq, Ord, Enum, Generic)
   deriving (FromJSON, ToJSON) via CustomJSON '[ConstructorTagModifier CamelToKebab] Repo
 


### PR DESCRIPTION
Test is currently failing due to this.

```
Test suite arch-web-test: RUNNING...
### Failure in: 2:searchPackage
test/Main.hs:28
DecodeFailure "Error in $.results[100].repo: parsing Web.ArchLinux.Types.Repo failed, expected one of the tags [\"core\",\"extra\",\"testing\",\"multilib\",\"multilib-testing\",\"community\",\"community-testing\"], but found tag \"kde-unstable\""
```