### PR TITLE
Support aeson 2.2

### DIFF
--- a/arch-web.cabal
+++ b/arch-web.cabal
@@ -23,7 +23,7 @@ tested-with:     GHC ==8.10.7 || ==9.0.2
 
 common common
   build-depends:
-    , aeson                ^>=1.5.4 || ^>=2.0 || ^>=2.1
+    , aeson                ^>=1.5.4 || ^>=2.0 || ^>=2.1 || ^>=2.2
     , base                 >=4.10   && <5
     , deriving-aeson       ^>=0.2.6
     , exceptions           ^>=0.10.4


### PR DESCRIPTION
Builds and tests without issues on 9.0.2, haven't gotten around to build with other GHC versions yet.